### PR TITLE
Bug Fix: Microphone Stops Recording After ~10 Audios

### DIFF
--- a/src/flutter_sound_recorder.js
+++ b/src/flutter_sound_recorder.js
@@ -22,9 +22,6 @@ const IS_RECORDER_PAUSED = 1;
 const IS_RECORDER_RECORDING = 2;
 const IS_RECORDER_STOPPED = 0;
 
-const audioContext = new AudioContext();
-
-
 function newRecorderInstance(aCallback, callbackTable) { return new FlutterSoundRecorder(aCallback, callbackTable); }
 
 

--- a/src/flutter_sound_recorder.js
+++ b/src/flutter_sound_recorder.js
@@ -22,6 +22,9 @@ const IS_RECORDER_PAUSED = 1;
 const IS_RECORDER_RECORDING = 2;
 const IS_RECORDER_STOPPED = 0;
 
+const audioContext = new AudioContext();
+
+
 function newRecorderInstance(aCallback, callbackTable) { return new FlutterSoundRecorder(aCallback, callbackTable); }
 
 
@@ -181,9 +184,9 @@ class FlutterSoundRecorder {
                 mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
                 me.mediaStream = mediaStream;
 
-                const audioContext = new AudioContext();
-                const _audioSource = audioContext.createMediaStreamSource(mediaStream);
-                const analyser = audioContext.createAnalyser();
+                this.audioContext = new AudioContext();
+                const _audioSource = this.audioContext.createMediaStreamSource(mediaStream);
+                const analyser = this.audioContext.createAnalyser();
                 // todo: review if this values are right (set to mimic a behaviour closest to that of Android)
                 analyser.fftSize = 512;
                 analyser.minDecibels = -110;
@@ -367,6 +370,11 @@ class FlutterSoundRecorder {
                         this.mediaStream.getTracks().forEach(track => track.stop());
                         this.mediaStream = null;
                 }
+                  // Close the audioContext if it exists
+                if (this.audioContext != null) {
+                        this.audioContext.close();
+                        this.audioContext = null;
+                }
                 this.callbackTable[CB_recorder_log](this.callback, DBG, 'JS:<--- stop()');
         }
 
@@ -383,6 +391,11 @@ class FlutterSoundRecorder {
                 if (this.mediaStream != null) {
                         this.mediaStream.getTracks().forEach(track => track.stop());
                         this.mediaStream = null;
+                }
+                  // Close the audioContext if it exists
+                if (this.audioContext != null) {
+                        this.audioContext.close();
+                        this.audioContext = null;
                 }
                 this.callbackTable[CB_recorder_log](this.callback, DBG, "JS:<--- stopRecorder");
         }


### PR DESCRIPTION
*(I’m unsure if this is the correct way to propose a fix for the package, so I apologize if I’m not following the proper procedure.)*

This fix addresses an issue where, after recording approximately 10 audio clips, the microphone would stop functioning.

## Root Cause:
The problem originated from the `startRecorder` function, which created a new `AudioContext` for each recording session without properly closing the previous ones. Some browsers, such as Google Chrome, impose a limit on the number of active `AudioContexts`—typically around 10. Once this limit is exceeded, further recordings are blocked, leading to the following JavaScript error:

> The AudioContext encountered an error from the audio device or the WebAudio renderer.

![image](https://github.com/user-attachments/assets/6b26cdc0-58d7-4e8b-b8b4-a7e6385d7dff)

Additionally, while profiling in Google Chrome, the error message:

> Number of opened output audio streams 10 exceeded the max allowed number 10.

This confirmed that the issue was related to the excessive number of `AudioContexts` being opened without closure.

![image](https://github.com/user-attachments/assets/5e23c1b2-5c5b-443a-9827-7ec20e958b40)

## Solution:
This fix ensures that `stopRecorder` properly closes the `AudioContext` initiated by `startRecorder`, preventing the accumulation of open contexts.

## Device-Specific Reproduction:
This bug did not appear on all browsers or devices; however, it was reproducible on the Google Chrome app running on an Android Samsung Galaxy A55 (128GB) in both the development and release versions. The application in question posed questions and recorded user answers without ever reloading the page.